### PR TITLE
Fix sticker path replacement in Chat component

### DIFF
--- a/src/lib/Chat.svelte
+++ b/src/lib/Chat.svelte
@@ -17,7 +17,7 @@
   import: 'default',
 });
     console.log(stickerFiles)
-    const stickers = Object.keys(stickerFiles).map(path => path.replace('/public', '/Liars-Dice-Svelte'));
+    const stickers = Object.keys(stickerFiles).map(path => path.replace('/public', ''));
     console.log(stickers)
 
     function scrollToBottom() {


### PR DESCRIPTION
Correct the path replacement for sticker files in the Chat component to ensure proper loading of stickers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Adjusted how sticker asset paths are processed to ensure stickers display correctly in the chat interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->